### PR TITLE
list function in controller renamed for backwards php compatibility

### DIFF
--- a/fields/index/controller.php
+++ b/fields/index/controller.php
@@ -5,7 +5,7 @@ require __DIR__ . DS . 'options.php';
 class IndexFieldController extends Kirby\Panel\Controllers\Field {
 
   // get entries for the current table
-  public function list () {
+  public function list_entries () {
     $field = $this->field();
     $data = Kirby\Panel\Form\IndexFieldOptions::build($field);
     if ($field->filter()) {

--- a/fields/index/index.php
+++ b/fields/index/index.php
@@ -26,7 +26,7 @@ class IndexField extends BaseField {
       array(
         'pattern' => 'list',
         'method'  => 'get',
-        'action'  => 'list'
+        'action'  => 'list_entries'
       )
     );
   }


### PR DESCRIPTION
In the controller file the function was named "list" which is a reserved keyword in PHP. Only PHP7 made it possible to create functions with this name. For more details please visit: https://stackoverflow.com/a/6833077
After changing this function name to a different one now it is possible to use this module on servers with PHP5.6 (maybe older)