### PR TITLE
Fix incorrect URL's in panel (multilang)

### DIFF
--- a/fields/index/options.php
+++ b/fields/index/options.php
@@ -189,7 +189,7 @@ class IndexFieldOptions {
       if (isset($item['filename'])) {
         $item['panelurl'] = panel()->urls()->index() . '/pages/' . $this->activepage->uri() . '/file/' . $item['filename'] . '/edit';
       } else {
-        $item['panelurl'] = panel()->urls()->index() . '/pages/' . $item['uri'] . '/edit';
+        $item['panelurl'] = panel()->urls()->index() . '/pages/' . $item['id'] . '/edit';
       }
       return $item;
     }, $this->options->toArray());


### PR DESCRIPTION
When using a multilingual website, the URL's generated in the table of this index field point to the localized URL's.
But these don't work in the panel (when not in the default language) -> they should route to the URL in the default language.