### PR TITLE
Feature: "add" and "edit" buttons for files

### DIFF
--- a/fields/index/index.php
+++ b/fields/index/index.php
@@ -33,13 +33,24 @@ class IndexField extends BaseField {
 
   public function subpagelinks () {
     if (in_array($this->options, ['children', 'visibleChildren', 'invisibleChildren'])) {
+      $addLinks = true;
+      $hrefEdit = $this->page->url('subpages');
+      $hrefAdd = $this->page->url('add');
+      $addAttribute = 'data-modal="true"';
+    } else if (in_array($this->options, ['files', 'images', 'documents', 'videos', 'audio', 'code', 'archives'])) {
+      $hrefEdit = $this->page->url('files');
+      $hrefAdd = '#upload';
+      $addAttribute = 'data-upload';
+    }
+
+    if (is_string($addAttribute)) {
       return <<<HTML
         <span class="hgroup-options shiv shiv-dark shiv-left">
           <span class="hgroup-option-right">
-            <a href="{$this->page->url('subpages')}" title="Edit">
+            <a href="{$hrefEdit}" title="Edit">
               <i class="icon icon-left fa fa-pencil"></i><span>Edit</span>
             </a>
-            <a href="{$this->page->url('add')}" title="+" shortcut="+" data-modal="true">
+            <a href="{$hrefAdd}" title="+" shortcut="+" {$addAttribute}>
               <i class="icon icon-left fa fa-plus-circle"></i><span>Add</span>
             </a>
           </span>

--- a/fields/index/index.php
+++ b/fields/index/index.php
@@ -33,7 +33,6 @@ class IndexField extends BaseField {
 
   public function subpagelinks () {
     if (in_array($this->options, ['children', 'visibleChildren', 'invisibleChildren'])) {
-      $addLinks = true;
       $hrefEdit = $this->page->url('subpages');
       $hrefAdd = $this->page->url('add');
       $addAttribute = 'data-modal="true"';


### PR DESCRIPTION
This pull request adds the buttons/links for _adding_ files to and _editing_files of a page when using the plugin with file-related `options` such as `options: files` or `options: documents`.

This is especially useful in connection with [kirby-hidebar-field](https://github.com/jongacnik/kirby-hidebar-field) since the ability to _add_ and _edit_ files disappears completely.

