### PR TITLE
Fix panel URLs for filenames with dots

### DIFF
--- a/fields/index/options.php
+++ b/fields/index/options.php
@@ -187,9 +187,9 @@ class IndexFieldOptions {
     // add panel edit url to each item
     return array_map(function ($item) {
       if (isset($item['filename'])) {
-        $item['panelurl'] = panel()->urls()->index() . '/pages/' . $this->activepage->uri() . '/file/' . $item['filename'] . '/edit';
+        $item['panelurl'] = $this->activepage->file($item['filename'])->url('edit');
       } else {
-        $item['panelurl'] = panel()->urls()->index() . '/pages/' . $item['id'] . '/edit';
+        $item['panelurl'] = panel()->page($item['id'])->url('edit');
       }
       return $item;
     }, $this->options->toArray());


### PR DESCRIPTION
`panelurl` for filenames containing _dots_ are not generated correctly.

The original code leads to links such as: 
http://localhost:3000/panel/pages/mytest/file/Test%20PPTX.pptx/edit

This link is not to be valid and triggers a _Not Found_ page.

This pull request changes the encoding of `panelurl` for valid links:
http://localhost:3000/panel/pages/mytest/file/Test%20PPTX%E2%80%A4pptx/edit

Furthermore, the pull request makes `panelurl` of pages more consistent.